### PR TITLE
debug erreurs + ajout pays frontières

### DIFF
--- a/R/produire_carte_statique.R
+++ b/R/produire_carte_statique.R
@@ -76,7 +76,7 @@ produire_carte_statique <- function(onde_df_mois = NULL,
       }
     })
 
-
+  # ajout des pays frontaliers pour gerer les departements avec de la terre
   pays_front <- sf::read_sf(dsn = "https://gisco-services.ec.europa.eu/distribution/v2/countries/geojson/CNTR_RG_01M_2024_4326.geojson") %>%
     dplyr::filter(NAME_FREN %in% c("Italie", "Suisse", "Luxembourg", "Espagne", "Belgique", "Allemagne", "Andorre", "France")) %>%
     sf::st_transform(crs = 2154)
@@ -121,20 +121,6 @@ produire_carte_statique <- function(onde_df_mois = NULL,
                observations = stringr::str_wrap(lib_ecoul4mod, 12),
                couleurs = Couleur_4mod)
     }
- # browser()
-
-  # if(code_departement %in% c(08)){
-  #   fond <- ggplot2::ggplot() +
-  #     ggplot2::geom_rect(data = dpt_shp,
-  #                        xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf,
-  #                        fill = "black")
-  # } else {
-  #   fond <- ggplot2::ggplot() +
-  #     ggplot2::geom_rect(data = dpt_shp,
-  #                        xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf,
-  #                        fill = "lightblue")
-  # }
-
 
   ggplot2::ggplot() +
     ggplot2::geom_sf(data = pays_front , fill = "lightgrey") +
@@ -190,7 +176,7 @@ produire_carte_statique <- function(onde_df_mois = NULL,
     ggplot2::labs(caption = paste("Source: ONDE (OFB)\n \u00a9OFB", format(Sys.time(), '%Y'), "- Date d\'\u00e9dition:", format(Sys.time(), '%d/%m/%Y'))) +
     ggplot2::theme_void() +
     ggplot2::theme(
-      legend.key = ggplot2::element_rect(fill = NA),
+      legend.key = ggplot2::element_rect(fill = NA), # retrait fond sur legende
       legend.text = ggplot2::element_text(size = 10),
       legend.title =  ggplot2::element_text(face = "bold",
                                             size = 9),
@@ -203,7 +189,7 @@ produire_carte_statique <- function(onde_df_mois = NULL,
       axis.title = ggplot2::element_blank(),
       axis.ticks.x = ggplot2::element_blank(),
       axis.ticks.y = ggplot2::element_blank(),
-      panel.background = ggplot2::element_rect(fill = "lightblue", colour = NA),
+      panel.background = ggplot2::element_rect(fill = "lightblue", colour = NA), # par defaut la mer
       panel.grid.major = ggplot2::element_line(colour = NA),
       panel.grid.minor = ggplot2::element_line(colour = NA),
       legend.position = "right",

--- a/R/produire_carte_statique.R
+++ b/R/produire_carte_statique.R
@@ -76,6 +76,12 @@ produire_carte_statique <- function(onde_df_mois = NULL,
       }
     })
 
+
+  pays_front <- sf::read_sf(dsn = "https://gisco-services.ec.europa.eu/distribution/v2/countries/geojson/CNTR_RG_01M_2024_4326.geojson") %>%
+    dplyr::filter(NAME_FREN %in% c("Italie", "Suisse", "Luxembourg", "Espagne", "Belgique", "Allemagne", "Andorre", "France")) %>%
+    sf::st_transform(crs = 2154)
+
+
   onde_df_mois <-
     onde_df_mois %>%
     dplyr::filter(code_departement == {
@@ -115,10 +121,23 @@ produire_carte_statique <- function(onde_df_mois = NULL,
                observations = stringr::str_wrap(lib_ecoul4mod, 12),
                couleurs = Couleur_4mod)
     }
+ # browser()
 
-  browser()
+  # if(code_departement %in% c(08)){
+  #   fond <- ggplot2::ggplot() +
+  #     ggplot2::geom_rect(data = dpt_shp,
+  #                        xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf,
+  #                        fill = "black")
+  # } else {
+  #   fond <- ggplot2::ggplot() +
+  #     ggplot2::geom_rect(data = dpt_shp,
+  #                        xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf,
+  #                        fill = "lightblue")
+  # }
+
 
   ggplot2::ggplot() +
+    ggplot2::geom_sf(data = pays_front , fill = "lightgrey") +
     ggplot2::geom_sf(data = dptFR_shp , fill = "grey95") +
     ggplot2::geom_sf(data = dpt_shp,
                      fill = "grey70",
@@ -174,6 +193,7 @@ produire_carte_statique <- function(onde_df_mois = NULL,
       legend.text = ggplot2::element_text(size = 10),
       legend.title =  ggplot2::element_text(face = "bold",
                                             size = 9),
+      legend.background = element_rect(colour = NA),
       plot.title = ggplot2::element_text(face = "bold",
                                          size = 10),
       plot.subtitle = ggplot2::element_text(face = "italic",

--- a/R/produire_carte_statique.R
+++ b/R/produire_carte_statique.R
@@ -43,6 +43,7 @@ produire_carte_statique <- function(onde_df_mois = NULL,
                                     referentiel_onde = 'Typologie nationale',
                                     couleurs = onde_4mod,
                                     dptFR_shp = NULL) {
+
   if (is.null(code_departement)) {
     stop("code dpt manquant")
   }
@@ -115,6 +116,8 @@ produire_carte_statique <- function(onde_df_mois = NULL,
                couleurs = Couleur_4mod)
     }
 
+  browser()
+
   ggplot2::ggplot() +
     ggplot2::geom_sf(data = dptFR_shp , fill = "grey95") +
     ggplot2::geom_sf(data = dpt_shp,
@@ -161,7 +164,7 @@ produire_carte_statique <- function(onde_df_mois = NULL,
     ) +
     ggplot2::ggtitle(
       label = glue::glue(
-        'R\u00e9seau ONDE - {unique(onde_df_mois$libelle_departement)} - Campagne {unique(onde_df_mois$libelle_type_campagne)} {unique(lubridate::month(onde_df_mois$date_campagne,label = T, locale = \"fr_FR\"))} {unique(lubridate::year(onde_df_mois$date_campagne))}'
+        'R\u00e9seau ONDE - {unique(onde_df_mois$libelle_departement)} - Campagne {unique(onde_df_mois$libelle_type_campagne)} {unique(lubridate::month(onde_df_mois$date_campagne,label = T))} {unique(lubridate::year(onde_df_mois$date_campagne))}'
       ),
       subtitle = glue::glue('{referentiel_onde}')
     ) +

--- a/R/produire_carte_statique.R
+++ b/R/produire_carte_statique.R
@@ -76,6 +76,12 @@ produire_carte_statique <- function(onde_df_mois = NULL,
       }
     })
 
+
+  pays_front <- sf::read_sf(dsn = "https://gisco-services.ec.europa.eu/distribution/v2/countries/geojson/CNTR_RG_01M_2024_4326.geojson") %>%
+    dplyr::filter(NAME_FREN %in% c("Italie", "Suisse", "Luxembourg", "Espagne", "Belgique", "Allemagne", "Andorre", "France")) %>%
+    sf::st_transform(crs = 2154)
+
+
   onde_df_mois <-
     onde_df_mois %>%
     dplyr::filter(code_departement == {
@@ -115,11 +121,24 @@ produire_carte_statique <- function(onde_df_mois = NULL,
                observations = stringr::str_wrap(lib_ecoul4mod, 12),
                couleurs = Couleur_4mod)
     }
+ # browser()
 
-  browser()
+  # if(code_departement %in% c(08)){
+  #   fond <- ggplot2::ggplot() +
+  #     ggplot2::geom_rect(data = dpt_shp,
+  #                        xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf,
+  #                        fill = "black")
+  # } else {
+  #   fond <- ggplot2::ggplot() +
+  #     ggplot2::geom_rect(data = dpt_shp,
+  #                        xmin = -Inf, xmax = Inf, ymin = -Inf, ymax = Inf,
+  #                        fill = "lightblue")
+  # }
+
 
   ggplot2::ggplot() +
-    ggplot2::geom_sf(data = dptFR_shp , fill = "grey95") +
+    ggplot2::geom_sf(data = pays_front , fill = "grey90") +
+    ggplot2::geom_sf(data = dptFR_shp , fill = "floralwhite") +
     ggplot2::geom_sf(data = dpt_shp,
                      fill = "grey70",
                      lwd = 1.2) +
@@ -171,9 +190,11 @@ produire_carte_statique <- function(onde_df_mois = NULL,
     ggplot2::labs(caption = paste("Source: ONDE (OFB)\n \u00a9OFB", format(Sys.time(), '%Y'), "- Date d\'\u00e9dition:", format(Sys.time(), '%d/%m/%Y'))) +
     ggplot2::theme_void() +
     ggplot2::theme(
+      legend.key = ggplot2::element_rect(fill = NA),
       legend.text = ggplot2::element_text(size = 10),
       legend.title =  ggplot2::element_text(face = "bold",
                                             size = 9),
+      # legend.background = element_rect(colour = NA),
       plot.title = ggplot2::element_text(face = "bold",
                                          size = 10),
       plot.subtitle = ggplot2::element_text(face = "italic",

--- a/inst/rmarkdown/templates/rapport_mensuel_onde_dpt/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/rapport_mensuel_onde_dpt/skeleton/skeleton.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Bilan zaza mensuel ONDE  \nObservatoire national des étiages  \nDépartement `r params$code_departement`"
+title: "Bilan mensuel ONDE  \nObservatoire national des étiages  \nDépartement `r params$code_departement`"
 author: "OFB, DR `r params$region_dr`"
 date: "Campagne `r params$type_rapport` de `r params$mois_rapport`  \nrapport créé le `r format(Sys.time(), '%d %B %Y')`"
 output: 
@@ -135,11 +135,6 @@ onde_bilan_ecoulement_annee_dpt <-
                                            "Donnée manquante"),
                             referentiel_onde = "Typologie départementale",
                             force_complementaire = T)
-```
-
-```{r}
-
-print("zaza")
 ```
 
 Actuellement, le **département `r params$code_departement`** est couvert par **`r nb_stations` stations** d'observations. 

--- a/inst/rmarkdown/templates/rapport_mensuel_onde_dpt/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/rapport_mensuel_onde_dpt/skeleton/skeleton.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Bilan mensuel ONDE  \nObservatoire national des étiages  \nDépartement `r params$code_departement`"
+title: "Bilan zaza mensuel ONDE  \nObservatoire national des étiages  \nDépartement `r params$code_departement`"
 author: "OFB, DR `r params$region_dr`"
 date: "Campagne `r params$type_rapport` de `r params$mois_rapport`  \nrapport créé le `r format(Sys.time(), '%d %B %Y')`"
 output: 
@@ -135,6 +135,11 @@ onde_bilan_ecoulement_annee_dpt <-
                                            "Donnée manquante"),
                             referentiel_onde = "Typologie départementale",
                             force_complementaire = T)
+```
+
+```{r}
+
+print("zaza")
 ```
 
 Actuellement, le **département `r params$code_departement`** est couvert par **`r nb_stations` stations** d'observations. 
@@ -330,7 +335,7 @@ plot_historique <-
   patchwork::plot_annotation(tag_levels = "a",tag_suffix = ')',
                              #title = "Test",
                              caption = paste("Source: réseau ONDE (OFB)\n ©OFB", 
-                                             format(Sys.time(), '%Y'), "- Date d'édition:",format(Sys.time(), '%d/%m/%Y'))) &
+                                             format(Sys.time(), '%Y'), "- Date d'édition:",format(Sys.time(), '%d/%m/%Y'))) +
   theme(plot.title = element_text(size = 8, face='bold'),
         plot.tag = element_text(face = 'bold'))
 


### PR DESCRIPTION
-	Correction erreur de frappe dans le plot onde_bilan_ecoulement_annee_dpt
-	Retrait dans une fonction lubridate de l’argument « locale » (locale = \"fr_FR\") 
-	Ajout des pays frontaliers pour les cartes statiques
